### PR TITLE
Make @translations endpoint expandable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,14 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Breaking: rename the results attributes to be 'items'
+  [erral]
+
+- Breaking: remove 'language' attribute from top-level response
+  [erral]
+
+- Make `@translations` endpoint expandable
+  [erral]
 
 
 1.0.0 (2018-01-18)

--- a/docs/source/_json/expand_translations.req
+++ b/docs/source/_json/expand_translations.req
@@ -1,0 +1,3 @@
+GET /plone/en/test-document?expand=translations HTTP/1.1
+Accept: application/json
+Authorization: Basic YWRtaW46c2VjcmV0

--- a/docs/source/_json/expand_translations.resp
+++ b/docs/source/_json/expand_translations.resp
@@ -11,7 +11,7 @@ Content-Type: application/json
     }, 
     "translations": {
       "@id": "http://localhost:55001/plone/en/test-document/@translations", 
-      "translations": [
+      "items": [
         {
           "@id": "http://localhost:55001/plone/es/test-document", 
           "language": "es"
@@ -24,7 +24,7 @@ Content-Type: application/json
   }, 
   "@id": "http://localhost:55001/plone/en/test-document", 
   "@type": "Document", 
-  "UID": "9f7fa3587f494172b7c7c77b59d5c4e1", 
+  "UID": "28ca32f019ff4f7bb177f73b4f60a270", 
   "allowDiscussion": false, 
   "contributors": [], 
   "creation_date": "2016-10-21T21:00:00+02:00", 

--- a/docs/source/_json/expand_translations.resp
+++ b/docs/source/_json/expand_translations.resp
@@ -10,8 +10,7 @@ Content-Type: application/json
       "@id": "http://localhost:55001/plone/en/test-document/@navigation"
     }, 
     "translations": {
-      "@id": "http://localhost:55001/plone/en/test-document", 
-      "language": "en", 
+      "@id": "http://localhost:55001/plone/en/test-document/@translations", 
       "translations": [
         {
           "@id": "http://localhost:55001/plone/es/test-document", 
@@ -25,7 +24,7 @@ Content-Type: application/json
   }, 
   "@id": "http://localhost:55001/plone/en/test-document", 
   "@type": "Document", 
-  "UID": "923a80163f1f4344af89d1da02e9e355", 
+  "UID": "9f7fa3587f494172b7c7c77b59d5c4e1", 
   "allowDiscussion": false, 
   "contributors": [], 
   "creation_date": "2016-10-21T21:00:00+02:00", 

--- a/docs/source/_json/expand_translations.resp
+++ b/docs/source/_json/expand_translations.resp
@@ -1,0 +1,69 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "@components": {
+    "breadcrumbs": {
+      "@id": "http://localhost:55001/plone/en/test-document/@breadcrumbs"
+    }, 
+    "navigation": {
+      "@id": "http://localhost:55001/plone/en/test-document/@navigation"
+    }, 
+    "translations": {
+      "@id": "http://localhost:55001/plone/en/test-document", 
+      "language": "en", 
+      "translations": [
+        {
+          "@id": "http://localhost:55001/plone/es/test-document", 
+          "language": "es"
+        }
+      ]
+    }, 
+    "workflow": {
+      "@id": "http://localhost:55001/plone/en/test-document/@workflow"
+    }
+  }, 
+  "@id": "http://localhost:55001/plone/en/test-document", 
+  "@type": "Document", 
+  "UID": "923a80163f1f4344af89d1da02e9e355", 
+  "allowDiscussion": false, 
+  "contributors": [], 
+  "creation_date": "2016-10-21T21:00:00+02:00", 
+  "creators": [
+    "test_user_1_"
+  ], 
+  "description": {
+    "content-type": "text/plain", 
+    "data": ""
+  }, 
+  "effectiveDate": null, 
+  "excludeFromNav": false, 
+  "expirationDate": null, 
+  "id": "test-document", 
+  "is_folderish": false, 
+  "language": "en", 
+  "layout": "document_view", 
+  "location": "", 
+  "modification_date": "2016-10-21T21:00:00+02:00", 
+  "parent": {
+    "@id": "http://localhost:55001/plone/en", 
+    "@type": "Folder", 
+    "description": "", 
+    "review_state": "published", 
+    "title": "English"
+  }, 
+  "presentation": false, 
+  "relatedItems": [], 
+  "review_state": "private", 
+  "rights": {
+    "content-type": "text/plain", 
+    "data": ""
+  }, 
+  "subject": [], 
+  "tableContents": false, 
+  "text": {
+    "content-type": "text/plain", 
+    "data": ""
+  }, 
+  "title": "Test document"
+}

--- a/docs/source/_json/translations_get.resp
+++ b/docs/source/_json/translations_get.resp
@@ -3,7 +3,7 @@ Content-Type: application/json
 
 {
   "@id": "http://localhost:55001/plone/en/test-document/@translations", 
-  "translations": [
+  "items": [
     {
       "@id": "http://localhost:55001/plone/es/test-document", 
       "language": "es"

--- a/docs/source/_json/translations_get.resp
+++ b/docs/source/_json/translations_get.resp
@@ -2,8 +2,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-  "@id": "http://localhost:55001/plone/en/test-document", 
-  "language": "en", 
+  "@id": "http://localhost:55001/plone/en/test-document/@translations", 
   "translations": [
     {
       "@id": "http://localhost:55001/plone/es/test-document", 

--- a/docs/source/_json/translations_is_expandable.req
+++ b/docs/source/_json/translations_is_expandable.req
@@ -1,0 +1,3 @@
+GET /plone/en/test-document HTTP/1.1
+Accept: application/json
+Authorization: Basic YWRtaW46c2VjcmV0

--- a/docs/source/_json/translations_is_expandable.resp
+++ b/docs/source/_json/translations_is_expandable.resp
@@ -18,7 +18,7 @@ Content-Type: application/json
   }, 
   "@id": "http://localhost:55001/plone/en/test-document", 
   "@type": "Document", 
-  "UID": "c4a20b2d492941c4a19a841d1bc65137", 
+  "UID": "a84bf480f30143f2bab158d6881e4645", 
   "allowDiscussion": false, 
   "contributors": [], 
   "creation_date": "2016-10-21T21:00:00+02:00", 

--- a/docs/source/_json/translations_is_expandable.resp
+++ b/docs/source/_json/translations_is_expandable.resp
@@ -10,8 +10,7 @@ Content-Type: application/json
       "@id": "http://localhost:55001/plone/en/test-document/@navigation"
     }, 
     "translations": {
-      "@id": "http://localhost:55001/plone/en/test-document", 
-      "language": "en"
+      "@id": "http://localhost:55001/plone/en/test-document/@translations"
     }, 
     "workflow": {
       "@id": "http://localhost:55001/plone/en/test-document/@workflow"
@@ -19,7 +18,7 @@ Content-Type: application/json
   }, 
   "@id": "http://localhost:55001/plone/en/test-document", 
   "@type": "Document", 
-  "UID": "0999900b36f7457e8cff273316481b98", 
+  "UID": "c4a20b2d492941c4a19a841d1bc65137", 
   "allowDiscussion": false, 
   "contributors": [], 
   "creation_date": "2016-10-21T21:00:00+02:00", 

--- a/docs/source/_json/translations_is_expandable.resp
+++ b/docs/source/_json/translations_is_expandable.resp
@@ -1,0 +1,63 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "@components": {
+    "breadcrumbs": {
+      "@id": "http://localhost:55001/plone/en/test-document/@breadcrumbs"
+    }, 
+    "navigation": {
+      "@id": "http://localhost:55001/plone/en/test-document/@navigation"
+    }, 
+    "translations": {
+      "@id": "http://localhost:55001/plone/en/test-document", 
+      "language": "en"
+    }, 
+    "workflow": {
+      "@id": "http://localhost:55001/plone/en/test-document/@workflow"
+    }
+  }, 
+  "@id": "http://localhost:55001/plone/en/test-document", 
+  "@type": "Document", 
+  "UID": "0999900b36f7457e8cff273316481b98", 
+  "allowDiscussion": false, 
+  "contributors": [], 
+  "creation_date": "2016-10-21T21:00:00+02:00", 
+  "creators": [
+    "test_user_1_"
+  ], 
+  "description": {
+    "content-type": "text/plain", 
+    "data": ""
+  }, 
+  "effectiveDate": null, 
+  "excludeFromNav": false, 
+  "expirationDate": null, 
+  "id": "test-document", 
+  "is_folderish": false, 
+  "language": "en", 
+  "layout": "document_view", 
+  "location": "", 
+  "modification_date": "2016-10-21T21:00:00+02:00", 
+  "parent": {
+    "@id": "http://localhost:55001/plone/en", 
+    "@type": "Folder", 
+    "description": "", 
+    "review_state": "published", 
+    "title": "English"
+  }, 
+  "presentation": false, 
+  "relatedItems": [], 
+  "review_state": "private", 
+  "rights": {
+    "content-type": "text/plain", 
+    "data": ""
+  }, 
+  "subject": [], 
+  "tableContents": false, 
+  "text": {
+    "content-type": "text/plain", 
+    "data": ""
+  }, 
+  "title": "Test document"
+}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,3 +16,4 @@ Contents
    :maxdepth: 2
 
    translations
+   upgrade-guide

--- a/docs/source/translations.rst
+++ b/docs/source/translations.rst
@@ -59,7 +59,7 @@ endpoint of the content item and provide the language code you want to unlink.:
 
 
 Expansion
-=========
+---------
 
 This endpoint uses the `expansion`_ mechanism of `plone.restapi`_ which allows to get additional
 information about a content item in one query, avoiding unnecesary requests.

--- a/docs/source/translations.rst
+++ b/docs/source/translations.rst
@@ -58,7 +58,37 @@ endpoint of the content item and provide the language code you want to unlink.:
    :language: http
 
 
+Expansion
+=========
+
+This endpoint uses the `expansion`_ mechanism of `plone.restapi`_ which allows to get additional
+information about a content item in one query, avoiding unnecesary requests.
+
+If a simple ``GET`` request is done on the content item, a new entry will be shown on the `@compoenents`
+entry with the URL of the `@translations` endpoint:
+
+..  http:example:: curl httpie python-requests
+    :request: _json/translations_is_expandable.req
+
+.. literalinclude:: _json/translations_is_expandable.resp
+   :language: http
+
+
+That means that, to include the translations of the item in the main content response, you can
+request to expand it:
+
+..  http:example:: curl httpie python-requests
+    :request: _json/expand_translations.req
+
+And the response will include the required information:
+
+.. literalinclude:: _json/expand_translations.resp
+   :language: http
+
+
+
 .. _`Products.LinguaPlone`: https://pypi.python.org/pypi/Products.LinguaPlone
 .. _`collective.restapi.pam`: https://pypi.python.org/pypi/collective.restapi.pam
 .. _`plone.app.multilingual`: https://pypi.python.org/pypi/plone.app.multilingual
 .. _`plone.restapi`: https://pypi.python.org/pypi/plone.restapi
+.. _`expansion`: https://plonerestapi.readthedocs.io/en/latest/expansion.html

--- a/docs/source/translations.rst
+++ b/docs/source/translations.rst
@@ -1,3 +1,5 @@
+.. _translations:
+
 LinguaPlone Translations
 ========================
 

--- a/docs/source/upgrade-guide.rst
+++ b/docs/source/upgrade-guide.rst
@@ -1,0 +1,18 @@
+Upgrade guide
+=============
+
+This upgrade guide lists all breaking changes in collective.restapi.linguaplone and explains the
+necessary steps that are needed to upgrade to the lastest version.
+
+Upgrading to collective.restapi.linguaplone 2.0.0
+-------------------------------------------------
+
+The JSON response to a GET requests to the :ref:`translations` endpoint does not include
+anymore the language of the actual content item.
+
+The JSON response to a GET requests to the :ref:`translations` endpoint includes the actual
+translations in an attribute called `items` instead of `translations`.
+
+These changes were done to behave like the other existing endpoints that are also expandable, which as
+top level information only include the name of the endpoint on the `id` attribute and the actual
+information in an attribute called `items`.

--- a/src/collective/restapi/linguaplone/configure.zcml
+++ b/src/collective/restapi/linguaplone/configure.zcml
@@ -4,6 +4,9 @@
 
   <includeDependencies package="." />
 
+
+  <adapter factory=".translations.Translations" name="translations"/>
+
   <plone:service
     method="GET"
     name="@translations"

--- a/src/collective/restapi/linguaplone/testing.py
+++ b/src/collective/restapi/linguaplone/testing.py
@@ -52,6 +52,7 @@ class CollectiveRestapiLinguaploneLayer(PloneSandboxLayer):
 
         portal.portal_languages.addSupportedLanguage('en')
         portal.portal_languages.addSupportedLanguage('es')
+        portal.portal_workflow.setDefaultChain("simple_publication_workflow")
 
 
 COLLECTIVE_RESTAPI_LINGUAPLONE_FIXTURE = CollectiveRestapiLinguaploneLayer()

--- a/src/collective/restapi/linguaplone/tests/test_documentation.py
+++ b/src/collective/restapi/linguaplone/tests/test_documentation.py
@@ -185,3 +185,19 @@ class TestDocumentation(unittest.TestCase):
                 "language": "es"
             })
         save_request_and_response_for_docs('translations_delete', response)
+
+
+    def test_translations_is_expandable(self):
+        self.en_content.addTranslationReference(self.es_content)
+        transaction.commit()
+        response = self.api_session.get(self.en_content.absolute_url())
+
+        save_request_and_response_for_docs('translations_is_expandable', response)
+
+    def test_expand_translations(self):
+        self.en_content.addTranslationReference(self.es_content)
+        transaction.commit()
+        response = self.api_session.get(
+            self.en_content.absolute_url() + '?expand=translations')
+
+        save_request_and_response_for_docs('expand_translations', response)

--- a/src/collective/restapi/linguaplone/tests/test_expansion.py
+++ b/src/collective/restapi/linguaplone/tests/test_expansion.py
@@ -1,0 +1,86 @@
+from collective.restapi.linguaplone.testing import COLLECTIVE_RESTAPI_LINGUAPLONE_FUNCTIONAL_TESTING
+from plone.app.testing import login
+from plone.app.testing import setRoles
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.app.testing import TEST_USER_ID
+from plone.dexterity.utils import createContentInContainer
+from plone.restapi.interfaces import IExpandableElement
+from plone.restapi.serializer.expansion import expandable_elements
+from plone.restapi.testing import RelativeSession
+from zope.component import getMultiAdapter
+from zope.component import provideAdapter
+from zope.interface import Interface
+from zope.interface import providedBy
+from zope.publisher.browser import TestRequest
+from zope.publisher.interfaces.browser import IBrowserRequest
+
+import unittest
+import transaction
+
+
+class TestExpansionFunctional(unittest.TestCase):
+
+    layer = COLLECTIVE_RESTAPI_LINGUAPLONE_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.portal_url = self.portal.absolute_url()
+        self.request = self.layer['request']
+        # self.portal.portal_languages.addSupportedLanguage('en')
+        # self.portal.portal_languages.addSupportedLanguage('es')
+        #  Setup the language root folders
+        login(self.portal, SITE_OWNER_NAME)
+        lsf = getMultiAdapter(
+            (self.portal, self.request),
+            name='language-setup-folders'
+        )
+        lsf()
+
+        en_id = self.portal.en.invokeFactory(
+            id='test-document',
+            type_name='Document',
+            title='Test document'
+        )
+        self.en_content = self.portal.en.get(en_id)
+
+        es_id = self.portal.es.invokeFactory(
+            id='test-document',
+            type_name='Document',
+            title='Test document'
+        )
+        self.es_content = self.portal.es.get(es_id)
+        self.en_content.addTranslationReference(self.es_content)
+
+        self.api_session = RelativeSession(self.portal_url)
+        self.api_session.headers.update({'Accept': 'application/json'})
+        self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
+
+        transaction.commit()
+
+    def test_translations_is_expandable(self):
+        response = self.api_session.get('/en/test-document')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            'translations',
+            response.json().get('@components').keys()
+        )
+
+    def test_translations_expanded(self):
+        response = self.api_session.get(
+            '/en/test-document',
+            params={
+                "expand": "translations"
+            }
+        )
+
+        self.assertEqual(response.status_code, 200)
+        translation_dict = {
+            '@id': self.es_content.absolute_url(),
+            'language': 'es'
+        }
+        self.assertIn(
+            translation_dict,
+            response.json()['@components']['translations']['translations']
+        )

--- a/src/collective/restapi/linguaplone/tests/test_expansion.py
+++ b/src/collective/restapi/linguaplone/tests/test_expansion.py
@@ -82,5 +82,5 @@ class TestExpansionFunctional(unittest.TestCase):
         }
         self.assertIn(
             translation_dict,
-            response.json()['@components']['translations']['translations']
+            response.json()['@components']['translations']['items']
         )

--- a/src/collective/restapi/linguaplone/tests/test_translations.py
+++ b/src/collective/restapi/linguaplone/tests/test_translations.py
@@ -51,8 +51,8 @@ class TestLPTranslationInfo(TestCase):
             name=u'GET_application_json_@translations')
 
         info = tinfo.reply()
-        self.assertIn('translations', info)
-        self.assertEqual(1, len(info['translations']))
+        self.assertIn('items', info)
+        self.assertEqual(1, len(info['items']))
 
     def test_correct_translation_information(self):
         tinfo = getMultiAdapter(
@@ -60,7 +60,7 @@ class TestLPTranslationInfo(TestCase):
             name=u'GET_application_json_@translations')
 
         info = tinfo.reply()
-        tinfo_es = info['translations'][0]
+        tinfo_es = info['items'][0]
         self.assertEqual(
             self.es_content.absolute_url(),
             tinfo_es['@id'])

--- a/src/collective/restapi/linguaplone/translations.py
+++ b/src/collective/restapi/linguaplone/translations.py
@@ -39,7 +39,7 @@ class Translations(object):
                 })
 
 
-        result['translations']['translations'] = translations
+        result['translations']['items'] = translations
         return result
 
 

--- a/src/collective/restapi/linguaplone/translations.py
+++ b/src/collective/restapi/linguaplone/translations.py
@@ -23,8 +23,7 @@ class Translations(object):
     def __call__(self, expand=False):
         result = {
             'translations': {
-                '@id': self.context.absolute_url(),
-                'language': self.context.Language(),
+                '@id': '{}/@translations'.format(self.context.absolute_url()),
             },
         }
         if not expand:


### PR DESCRIPTION
This PR makes the `@translations` endpoint expandable using the [expansion mechanism](https://plonerestapi.readthedocs.io/en/latest/expansion.html) of plone.restapi.

At the same time it removes the 'language' attribute on the response and renames the attribute that holds the translations to be 'items' instead of 'translations' to behave like other expandable endpoints (such as breadcrumbs or navigation').

The documentation includes an upgrade guide that explains these changes.